### PR TITLE
Add a permission node to force register.

### DIFF
--- a/src/main/java/uk/org/whoami/authme/listener/AuthMePlayerListener.java
+++ b/src/main/java/uk/org/whoami/authme/listener/AuthMePlayerListener.java
@@ -95,7 +95,7 @@ public class AuthMePlayerListener implements Listener {
         }
 
         if (!data.isAuthAvailable(name)) {
-            if (!Settings.isForcedRegistrationEnabled) {
+            if (!Settings.isForcedRegistrationEnabled || !player.hasPermission("authme.force.register") {
                 return;
             }
         }

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -43,6 +43,9 @@ permissions:
     authme.register:
         description: Register an account
         default: true
+    authme.force.register:
+        description: Force a player to register.
+        default: true
     authme.login:
         description: Login into a account
         default: true


### PR DESCRIPTION
Added a permission node authme.force.register to force some groups to register (used if the forced register is disabled in config.yml)
